### PR TITLE
Do not fail on empty CASACORE_INCLUDE_DIR

### DIFF
--- a/cmake/modules/FindCasaCore.cmake
+++ b/cmake/modules/FindCasaCore.cmake
@@ -60,17 +60,19 @@ if (LAPACK_FOUND)
     find_path(CASACORE_INCLUDE_DIR MeasurementSets.h
         HINTS ${CASACORE_INC_DIR}
         PATH_SUFFIXES casacore/ms ms)
-    get_filename_component(CASACORE_INCLUDE_DIR ${CASACORE_INCLUDE_DIR} DIRECTORY)
-    get_filename_component(CASACORE_INCLUDE_DIR ${CASACORE_INCLUDE_DIR} DIRECTORY)
-    foreach (module ${casacore_modules})
-        find_library(CASACORE_LIBRARY_${module} NAMES ${module}
-           HINTS ${CASACORE_LIB_DIR}
-           PATHS ENV CASACORE_LIBRARY_PATH
-           PATH_SUFFIXES lib)
-        mark_as_advanced(CASACORE_LIBRARY_${module})
-        list(APPEND CASACORE_LIBRARIES ${CASACORE_LIBRARY_${module}})
-     endforeach ()
-    list(APPEND CASACORE_LIBRARIES ${LAPACK_LIBRARIES})
+    if (CASACORE_INCLUDE_DIR)
+        get_filename_component(CASACORE_INCLUDE_DIR ${CASACORE_INCLUDE_DIR} DIRECTORY)
+        get_filename_component(CASACORE_INCLUDE_DIR ${CASACORE_INCLUDE_DIR} DIRECTORY)
+        foreach (module ${casacore_modules})
+            find_library(CASACORE_LIBRARY_${module} NAMES ${module}
+               HINTS ${CASACORE_LIB_DIR}
+               PATHS ENV CASACORE_LIBRARY_PATH
+               PATH_SUFFIXES lib)
+            mark_as_advanced(CASACORE_LIBRARY_${module})
+            list(APPEND CASACORE_LIBRARIES ${CASACORE_LIBRARY_${module}})
+         endforeach ()
+        list(APPEND CASACORE_LIBRARIES ${LAPACK_LIBRARIES})
+    endif()
 endif (LAPACK_FOUND)
 
 # handle the QUIETLY and REQUIRED arguments and set CASACORE_FOUND to TRUE if.


### PR DESCRIPTION
OSKAR was failing to build when no casacore installation was found cmake. My understanding (both from the documentation and from the code) is that casacore is an optional feature, but this bit of logic of cmake code wasn't handling this fact correctly.

This fixes the issue and OSKAR compiles fine now. Feel free to ask for any modifications if required.