### PR TITLE
Reacting to early cuda runtime errors

### DIFF
--- a/oskar/utility/src/oskar_device_utils.c
+++ b/oskar/utility/src/oskar_device_utils.c
@@ -67,8 +67,8 @@ int oskar_device_count(int *status)
     int num = 0;
     if (*status) return 0;
 #ifdef OSKAR_HAVE_CUDA
-    if (cudaGetDeviceCount(&num) != cudaSuccess)
-        num = 0;
+    *status = cudaGetDeviceCount(&num);
+    if (*status) return 0;
 #endif
     return num;
 }


### PR DESCRIPTION
In oskar_device_count the status flag was not being set when if a
problem was found during the call to cudaGetDeviceCount. That meant that
a call to oskar_device_count from oskar_interferometer_set_gpus failed
to recognize this problem, and behaved as if the call to
cudaGetDeviceCount had been successful (which wasn't, we were getting a
cudaErrorInsufficientDriver error when using cuda 10.0 in one of our
testing platforms). Probably similar treatment could be given to the rest of the functions in oskar_device_utils.

The oskar_cuda_system_info program handles this gracefully though,
because the underlying oskar_cuda_device_info_scan function does check
the return code from cudaGetDeviceCount.