### PR TITLE
Add support to open MS in read-only mode

### DIFF
--- a/oskar/ms/oskar_ms_open.h
+++ b/oskar/ms/oskar_ms_open.h
@@ -55,7 +55,7 @@ oskar_MeasurementSet* oskar_ms_open(const char* filename);
  * Opens an existing Measurement Set.
  */
 OSKAR_MS_EXPORT
-oskar_MeasurementSet* oskar_ms_open_ro(const char* filename);
+oskar_MeasurementSet* oskar_ms_open_readonly(const char* filename);
 
 #ifdef __cplusplus
 }

--- a/oskar/ms/oskar_ms_open.h
+++ b/oskar/ms/oskar_ms_open.h
@@ -48,6 +48,15 @@ extern "C" {
 OSKAR_MS_EXPORT
 oskar_MeasurementSet* oskar_ms_open(const char* filename);
 
+/**
+ * @brief Opens an existing Measurement Set in read-only mode.
+ *
+ * @details
+ * Opens an existing Measurement Set.
+ */
+OSKAR_MS_EXPORT
+oskar_MeasurementSet* oskar_ms_open_ro(const char* filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/oskar/ms/src/oskar_ms_open.cpp
+++ b/oskar/ms/src/oskar_ms_open.cpp
@@ -136,7 +136,7 @@ oskar_MeasurementSet* oskar_ms_open(const char* filename)
     return _oskar_ms_open(filename, false);
 }
 
-oskar_MeasurementSet* oskar_ms_open_ro(const char* filename)
+oskar_MeasurementSet* oskar_ms_open_readonly(const char* filename)
 {
     return _oskar_ms_open(filename, true);
 }

--- a/oskar/ms/src/oskar_ms_open.cpp
+++ b/oskar/ms/src/oskar_ms_open.cpp
@@ -37,7 +37,7 @@
 
 using namespace casacore;
 
-oskar_MeasurementSet* oskar_ms_open(const char* filename)
+static oskar_MeasurementSet* _oskar_ms_open(const char* filename, bool readonly)
 {
     oskar_MeasurementSet* p = (oskar_MeasurementSet*)
             calloc(1, sizeof(oskar_MeasurementSet));
@@ -45,8 +45,14 @@ oskar_MeasurementSet* oskar_ms_open(const char* filename)
     try
     {
         // Create the MeasurementSet. Storage managers are recreated as needed.
-        p->ms = new MeasurementSet(filename,
-                TableLock(TableLock::PermanentLocking), Table::Update);
+        TableLock::LockOption lock = TableLock::PermanentLocking;
+        Table::TableOption mode = Table::Update;
+        if (readonly)
+        {
+            lock = TableLock::NoLocking;
+            mode = Table::Old;
+        }
+        p->ms = new MeasurementSet(filename, lock, mode);
 
         // Create the MSMainColumns and MSColumns objects for accessing data
         // in the main table and subtables.
@@ -123,4 +129,14 @@ oskar_MeasurementSet* oskar_ms_open(const char* filename)
     p->end_time = range[1];
 
     return p;
+}
+
+oskar_MeasurementSet* oskar_ms_open(const char* filename)
+{
+    return _oskar_ms_open(filename, false);
+}
+
+oskar_MeasurementSet* oskar_ms_open_ro(const char* filename)
+{
+    return _oskar_ms_open(filename, true);
 }

--- a/python/oskar/measurement_set.py
+++ b/python/oskar/measurement_set.py
@@ -232,17 +232,18 @@ class MeasurementSet(object):
         return _measurement_set_lib.phase_centre_dec_rad(self._capsule)
 
     @classmethod
-    def open(cls, file_name):
+    def open(cls, file_name, readonly=False):
         """Opens an existing Measurement Set with the given name.
 
         Args:
             file_name (str):      File name of the Measurement Set to open.
+            readonly  (bool):     Open the Measurement Set in read-only mode.
         """
         if _measurement_set_lib is None:
             raise RuntimeError(
                 "OSKAR was compiled without Measurement Set support.")
         t = MeasurementSet()
-        t.capsule = _measurement_set_lib.open(file_name)
+        t.capsule = _measurement_set_lib.open(file_name, readonly)
         return t
 
     def read_column(self, column, start_row, num_rows):

--- a/python/oskar/src/oskar_measurement_set_lib.c
+++ b/python/oskar/src/oskar_measurement_set_lib.c
@@ -266,8 +266,12 @@ static PyObject* open(PyObject* self, PyObject* args)
     oskar_MeasurementSet* h = 0;
     PyObject *capsule = 0;
     const char* file_name = 0;
-    if (!PyArg_ParseTuple(args, "s", &file_name)) return 0;
-    h = oskar_ms_open(file_name);
+    PyObject *readonly;
+    if (!PyArg_ParseTuple(args, "sO", &file_name, &readonly)) return 0;
+    if (PyObject_IsTrue(readonly))
+        h = oskar_ms_open_ro(file_name);
+    else
+        h = oskar_ms_open(file_name);
 
     /* Check for errors. */
     if (!h)

--- a/python/oskar/src/oskar_measurement_set_lib.c
+++ b/python/oskar/src/oskar_measurement_set_lib.c
@@ -269,7 +269,7 @@ static PyObject* open(PyObject* self, PyObject* args)
     PyObject *readonly;
     if (!PyArg_ParseTuple(args, "sO", &file_name, &readonly)) return 0;
     if (PyObject_IsTrue(readonly))
-        h = oskar_ms_open_ro(file_name);
+        h = oskar_ms_open_readonly(file_name);
     else
         h = oskar_ms_open(file_name);
 


### PR DESCRIPTION
To avoid changing the API and ABI a new oskar_ms_open_ro function has been
added. In python an optional `readonly` parameter (defaults to `False`
for backwards compatibility) exposes the option to users.