### PR TITLE
Add missing #include <sys/types.h>

### DIFF
--- a/oskar/binary/src/oskar_binary_create.c
+++ b/oskar/binary/src/oskar_binary_create.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/oskar/binary/src/oskar_binary_read.c
+++ b/oskar/binary/src/oskar_binary_read.c
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Without these includes my compiler (gcc 9.1.0) complains about
    error: ‘off_t’ undeclared
in oskar_binary_create.c and oskar_binary_read.c
