### PR TITLE
Fix coordinate transformations to be in agreement with EveryBeam

### DIFF
--- a/oskar/convert/define_convert_theta_phi_to_ludwig3_components.h
+++ b/oskar/convert/define_convert_theta_phi_to_ludwig3_components.h
@@ -9,12 +9,10 @@
         GLOBAL FP4c *jones)\
 {\
     KERNEL_LOOP_X(int, i, 0, num)\
-    FP sin_p_x, cos_p_x, sin_p_y, cos_p_y;\
+    FP sin_phi, cos_phi;\
     FP2 x_theta_, x_phi_, y_theta_, y_phi_;\
     const FP p_x = phi_x[i];\
-    const FP p_y = phi_y[i];\
-    SINCOS(p_x, sin_p_x, cos_p_x);\
-    SINCOS(p_y, sin_p_y, cos_p_y);\
+    SINCOS(p_x, sin_phi, cos_phi);\
     const int j = i + offset;\
     if (swap_xy) {\
         x_theta_ = jones[j].c, x_phi_ = jones[j].d;\
@@ -23,14 +21,14 @@
         x_theta_ = jones[j].a, x_phi_ = jones[j].b;\
         y_theta_ = jones[j].c, y_phi_ = jones[j].d;\
     }\
-    jones[j].a.x = x_theta_.x * cos_p_x - x_phi_.x * sin_p_x;\
-    jones[j].a.y = x_theta_.y * cos_p_x - x_phi_.y * sin_p_x;\
-    jones[j].b.x = x_theta_.x * sin_p_x + x_phi_.x * cos_p_x;\
-    jones[j].b.y = x_theta_.y * sin_p_x + x_phi_.y * cos_p_x;\
-    jones[j].c.x = y_theta_.x * sin_p_y + y_phi_.x * cos_p_y;\
-    jones[j].c.y = y_theta_.y * sin_p_y + y_phi_.y * cos_p_y;\
-    jones[j].d.x = y_theta_.x * cos_p_y - y_phi_.x * sin_p_y;\
-    jones[j].d.y = y_theta_.y * cos_p_y - y_phi_.y * sin_p_y;\
+    jones[j].a.x = x_theta_.x * cos_phi - x_phi_.x * sin_phi;\
+    jones[j].a.y = x_theta_.y * cos_phi - x_phi_.y * sin_phi;\
+    jones[j].b.x = x_theta_.x * sin_phi + x_phi_.x * cos_phi;\
+    jones[j].b.y = x_theta_.y * sin_phi + x_phi_.y * cos_phi;\
+    jones[j].c.x = y_theta_.x * cos_phi - y_phi_.x * sin_phi;\
+    jones[j].c.y = y_theta_.y * cos_phi - y_phi_.y * sin_phi;\
+    jones[j].d.x = y_theta_.x * sin_phi + y_phi_.x * cos_phi;\
+    jones[j].d.y = y_theta_.y * sin_phi + y_phi_.y * cos_phi;\
     KERNEL_LOOP_END\
 }\
 OSKAR_REGISTER_KERNEL(NAME)

--- a/oskar/telescope/station/element/define_evaluate_spherical_wave.h
+++ b/oskar/telescope/station/element/define_evaluate_spherical_wave.h
@@ -82,11 +82,11 @@ KERNEL(NAME) (\
             }\
         }\
     }\
-    /* For some reason all components must be reversed in the matrix. */\
-    pattern[i + offset].a = Yp;\
-    pattern[i + offset].b = Yt;\
-    pattern[i + offset].c = Xp;\
-    pattern[i + offset].d = Xt;\
+    /* For some reason the theta/phi components must be reversed? */\
+    pattern[i + offset].a = Xp;\
+    pattern[i + offset].b = Xt;\
+    pattern[i + offset].c = Yp;\
+    pattern[i + offset].d = Yt;\
     KERNEL_LOOP_END\
 }\
 OSKAR_REGISTER_KERNEL(NAME)


### PR DESCRIPTION
This fixes two problems that prevented agreement between the OSKAR and EveryBeam beam patterns.
1. When the coefficients for the x-dipole where set to zero, the y-dipole beam pattern was zero instead, and vice versa
2. When the coefficients of the x-dipole and the y-dipole are the same, there was a sign difference between de x and y beampatterns
