### PR TITLE
Adding missing FindPackageHandlesStandardArgs include to FindCASACORE.cmake

### DIFF
--- a/oskar/ms/cmake/FindCASACORE.cmake
+++ b/oskar/ms/cmake/FindCASACORE.cmake
@@ -78,6 +78,7 @@ endif(1)
 
 # handle the QUIETLY and REQUIRED arguments and set CASACORE_FOUND to TRUE if
 # all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(CASACORE DEFAULT_MSG
     CASACORE_LIBRARIES CASACORE_INCLUDE_DIR)
 


### PR DESCRIPTION
Minor fix to include the `FindPackageHandlesStandardArgs` CMake module (https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html). Without this include, CMake version 3.16.3 raises an error. I've not checked other versions of CMake but given in the past this issue was not noticed, it's quite likely many versions of CMake were previously loading this module implicitly.
