### PR TITLE
Fix MSv3b ELEMENT_OFFSET dimensions

### DIFF
--- a/oskar/ms/src/oskar_ms_accessors.cpp
+++ b/oskar/ms/src/oskar_ms_accessors.cpp
@@ -254,12 +254,12 @@ void oskar_ms_set_element_coords(
     // https://casacore.github.io/casacore-notes/264.pdf
     Matrix<Bool> flags(
             IPosition(2, num_elements, (p->num_pols == 4 ? 2 : 1)), false);
-    Matrix<Double> offset(IPosition(2, num_elements, 3));
+    Matrix<Double> offset(IPosition(2, 3, num_elements));
     for (unsigned int i = 0; i < num_elements; ++i)
     {
-        offset(i, 0) = x[i];
-        offset(i, 1) = y[i];
-        offset(i, 2) = z[i];
+        offset(0, i) = x[i];
+        offset(1, i) = y[i];
+        offset(2, i) = z[i];
     }
     antennaId.put(station, station);
     position.put(station, pos);


### PR DESCRIPTION
According to the [MSv3b spec](https://casacore.github.io/casacore-notes/264.pdf) the `PHASED_ARRAY/ELEMENT_OFFSET` column has shape `(3, Nant)`, but OSKAR outputs in the reversed dimension order.